### PR TITLE
Add `Requires PHP` header

### DIFF
--- a/add-settings-linksv9.php
+++ b/add-settings-linksv9.php
@@ -6,22 +6,13 @@
  * Author: Jazir5
  * Text Domain: add-settings-links
  * Domain Path: /languages
+ * Requires PHP: 7.4
  */
 
 namespace ASL;
 
 if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
-}
-
-// PHP Version Check
-if (version_compare(PHP_VERSION, '7.4', '<')) {
-    add_action('admin_notices', function(): void {
-        echo '<div class="notice notice-error"><p>';
-        esc_html_e('Add Settings Links requires PHP version 7.4 or higher. Please update your PHP version.', 'add-settings-links');
-        echo '</p></div>';
-    });
-    return;
 }
 
 /**


### PR DESCRIPTION
Removes the code that checks the PHP version in favour of using WordPress's own PHP version header and system

https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/